### PR TITLE
Use `cygstart` instead of `open` in cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,9 +104,9 @@ pep8: .depends-test
 .PHONY: pylint
 pylint: depends
 	$(PYLINT) $(PACKAGE) --reports no \
-						 --msg-template="{msg_id}:{line:3d},{column}:{msg}" \
-						 --max-line-length=79 \
-						 --disable=I0011,W0142,W0511,R0801
+	                     --msg-template="{msg_id}:{line:3d},{column}:{msg}" \
+	                     --max-line-length=79 \
+	                     --disable=I0011,W0142,W0511,R0801
 
 .PHONY: check
 check: depends


### PR DESCRIPTION
Check `sys.platform` and decide the value of $(OPEN)
