### PR TITLE
Make Python 3.4 the minimum version and switch to venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ __pycache__
 # Temporary OS files
 Icon*
 
-# Temporary virtualenv files
-.cache
+# Temporary virtual environment
 env
 
 # Generated documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 3.3
 - 3.4
 install:
 - pip install coveralls scrutinizer-ocular

--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,13 @@ PLATFORM := $(shell python -c 'import sys; print(sys.platform)')
 ifneq ($(findstring win32, $(PLATFORM)), )
 	SYS_PYTHON_DIR := C:\\Python$(PYTHON_MAJOR)$(PYTHON_MINOR)
 	SYS_PYTHON := $(SYS_PYTHON_DIR)\\python.exe
-	SYS_VIRTUALENV := $(SYS_PYTHON_DIR)\\Scripts\\virtualenv.exe
 	# https://bugs.launchpad.net/virtualenv/+bug/449537
 	export TCL_LIBRARY=$(SYS_PYTHON_DIR)\\tcl\\tcl8.5
 else
 	SYS_PYTHON := python$(PYTHON_MAJOR)
-	SYS_VIRTUALENV := virtualenv
 endif
 
-# virtualenv paths (automatically detected from the system Python)
+# Virtual environment paths (automatically detected from the system Python)
 ENV := env
 ifneq ($(findstring win32, $(PLATFORM)), )
 	BIN := $(ENV)/Scripts
@@ -35,7 +33,7 @@ else
 	endif
 endif
 
-# virtualenv executables
+# Virtual environment executables
 PYTHON := $(BIN)/python
 PIP := $(BIN)/pip
 EASY_INSTALL := $(BIN)/easy_install
@@ -66,15 +64,15 @@ ci: pep8 pep257 test tests
 # Development Installation ###################################################
 
 .PHONY: env
-env: .virtualenv $(EGG_INFO)
+env: .venv $(EGG_INFO)
 $(EGG_INFO): Makefile setup.py
 	$(PYTHON) setup.py develop
 	touch $(EGG_INFO)  # flag to indicate package is installed
 
-.PHONY: .virtualenv
-.virtualenv: $(PIP)
-$(PIP):
-	$(SYS_VIRTUALENV) --python $(SYS_PYTHON) $(ENV)
+.PHONY: .venv
+.venv: $(PYTHON)
+$(PYTHON):
+	$(SYS_PYTHON) -m venv $(ENV)
 
 .PHONY: depends
 depends: .depends-ci .depends-dev

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Getting Started
 Requirements
 ------------
 
-* Python 3.3+
+* Python 3.4+
 
 
 Installation
@@ -65,7 +65,6 @@ Requirements
     * Windows: http://cygwin.com/install.html
     * Mac: https://developer.apple.com/xcode
     * Linux: http://www.gnu.org/software/make (likely already installed)
-* virtualenv: https://pypi.python.org/pypi/virtualenv#installation
 * Pandoc: http://johnmacfarlane.net/pandoc/installing.html
 * Graphviz: http://www.graphviz.org/Download.php
 
@@ -73,7 +72,7 @@ Requirements
 Installation
 ------------
 
-Create a virtualenv:
+Create a virtual environment:
 
     $ make env
 

--- a/foobar/__init__.py
+++ b/foobar/__init__.py
@@ -6,3 +6,9 @@ __project__ = 'Foobar'
 __version__ = '0.0.0'
 
 VERSION = __project__ + '-' + __version__
+
+MIN_PYTHON_VERSION = 3, 4
+
+import sys
+if not sys.version_info >= MIN_PYTHON_VERSION:  # pragma: no cover (manual test)
+    exit("Python %s.%s+ is required." % MIN_PYTHON_VERSION)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         'Development Status :: 1 - Planning',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
 
     install_requires=[],


### PR DESCRIPTION
A talk given by @brousch reminded me that Python 3.4 removed the need to install any third party modules by using the built-in `pip` and `venv`.