### PR TITLE
Let pip use a local download cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ clean-all: clean clean-env .clean-workspace .clean-cache
 
 .PHONY: .clean-cache
 .clean-cache:
-	rm -rf .cache
+	rm -rf $(PIP_CACHE_DIR)
 
 .PHONY: .clean-workspace
 .clean-workspace:


### PR DESCRIPTION
This noticeably speeds up the time it takes to reinstall dependencies.
