### PR TITLE
Switch default license to MIT

### DIFF
--- a/{{cookiecutter.project_name}}/LICENSE.txt
+++ b/{{cookiecutter.project_name}}/LICENSE.txt
@@ -1,13 +1,21 @@
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                    Version 2, December 2004
+The MIT License (MIT)
 
- Copyright (C) 2014 {{cookiecutter.full_name}} <{{cookiecutter.email}}>
+Copyright (c) 2014 {{cookiecutter.full_name}} <{{cookiecutter.email}}>
 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-  0. You just DO WHAT THE FUCK YOU WANT TO.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     entry_points={'console_scripts': []},
 
     long_description=(README + '\n' + CHANGES),
-    license='WTFPL',
+    license='MIT',
     classifiers=[
         'Development Status :: 1 - Planning',
         'Natural Language :: English',


### PR DESCRIPTION
I think this is a more reasonable default. The reason for WTFPL initially was that, pre-cookiecutter, the entire project was the template and it would be a little difficult to determine what was licensed.
