### PR TITLE
Use pre-created travis virtualenv if applicable

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -2,6 +2,10 @@
 ifndef TRAVIS
 	PYTHON_MAJOR := {{cookiecutter.python_major_version}}
 	PYTHON_MINOR := {{cookiecutter.python_minor_version}}
+	ENV := env
+else
+	# Use the virtualenv provided by Travis
+	ENV := $(VIRTUAL_ENV)
 endif
 
 # Test runner settings
@@ -33,7 +37,6 @@ else
 endif
 
 # virtualenv paths
-ENV := env
 ifneq ($(findstring win32, $(PLATFORM)), )
 	BIN := $(ENV)/Scripts
 	OPEN := cmd /c start

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -3,9 +3,12 @@ ifndef TRAVIS
 	PYTHON_MAJOR := {{cookiecutter.python_major_version}}
 	PYTHON_MINOR := {{cookiecutter.python_minor_version}}
 	ENV := env
+	ENV2 := $(ENV)
 else
 	# Use the virtualenv provided by Travis
 	ENV := $(VIRTUAL_ENV)
+	mkdir -p $(VIRTUAL_ENV)/env
+	ENV2 := $(VIRTUAL_ENV)/env
 endif
 
 # Test runner settings
@@ -89,7 +92,7 @@ ci: check test tests
 .PHONY: env
 env: .virtualenv $(EGG_INFO)
 $(EGG_INFO): Makefile setup.py requirements.txt
-	VIRTUAL_ENV=$(ENV) $(PYTHON) setup.py develop
+	VIRTUAL_ENV=$(ENV2) $(PYTHON) setup.py develop
 	touch $(EGG_INFO)  # flag to indicate package is installed
 
 .PHONY: .virtualenv

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -7,8 +7,7 @@ ifndef TRAVIS
 else
 	# Use the virtualenv provided by Travis
 	ENV := $(VIRTUAL_ENV)
-	mkdir -p $(VIRTUAL_ENV)/env
-	ENV2 := $(VIRTUAL_ENV)/env
+	ENV2 := $(ENV)/env
 endif
 
 # Test runner settings
@@ -92,6 +91,7 @@ ci: check test tests
 .PHONY: env
 env: .virtualenv $(EGG_INFO)
 $(EGG_INFO): Makefile setup.py requirements.txt
+	mkdir -p $(ENV2)
 	VIRTUAL_ENV=$(ENV2) $(PYTHON) setup.py develop
 	touch $(EGG_INFO)  # flag to indicate package is installed
 


### PR DESCRIPTION
Saves a bit of time by not creating a second virtualenv within the Travis virtualenv.