### PR TITLE
Remove a few warnings

### DIFF
--- a/{{cookiecutter.project_name}}/.pylintrc
+++ b/{{cookiecutter.project_name}}/.pylintrc
@@ -1,10 +1,11 @@
 [MESSAGES CONTROL]
 
-# I0011: Locally disabling %s
+# I0011: Locally disabling warning
 # W0142: Used * or ** magic
 # W0511: TODO in comments
+# RO903: Too few public methods
 # R0904: Too many public methods
-disable=I0011,W0142,W0511,R0904
+disable=I0011,W0142,W0511,R0903,R0904
 
 [REPORTS]
 

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -147,11 +147,14 @@ check: pep8 pep257 pylint
 
 .PHONY: pep8
 pep8: depends-ci
+	# E501: line too long (checked by PyLint)
 	$(PEP8) $(PACKAGE) --ignore=E501
 
 .PHONY: pep257
 pep257: depends-ci
-	$(PEP257) $(PACKAGE)
+	# D102: docstring missing (checked by PyLint)
+	# D202: No blank lines allowed *after* function docstring
+	$(PEP257) $(PACKAGE) --ignore=D102,D202
 
 .PHONY: pylint
 pylint: depends-ci


### PR DESCRIPTION
Reasoning:

* PyLint R0903: “Too few public methods” is just as harmless and
obvious as “Too many public methods”, Scrutinizer does a better job of
tracking this over time
* PEP257 D102: “docstring missing” is checked by PyLint
* PEP257 D202: “No blank lines allowed *after* function docstring” is
sometimes nice to have when using block comments