### PR TITLE
set CHANGES.md merge type to union

### DIFF
--- a/{{cookiecutter.project_name}}/.gitattributes
+++ b/{{cookiecutter.project_name}}/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+CHANGES.md merge=union


### PR DESCRIPTION
Makes it easier to update change log without creating merge conflicts when new items are added to the same position in the list.

From [the docs](http://git-scm.com/docs/gitattributes) about `merge=union`

> Run 3-way file level merge for text files, but take lines from both versions, instead of leaving conflict markers. This tends to leave the added lines in the resulting file in random order and the user should verify the result. Do not use this if you do not understand the implications.