### PR TITLE
Ensure pip is the latest version when creating the virtualenv

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -91,6 +91,7 @@ $(EGG_INFO): Makefile setup.py requirements.txt
 .virtualenv: $(PIP)
 $(PIP):
 	$(SYS_VIRTUALENV) --python $(SYS_PYTHON) $(ENV)
+	$(PIP) install --upgrade pip
 
 .PHONY: depends
 depends: depends-ci depends-dev


### PR DESCRIPTION
I keep seeing the following warning every time I re-create the virtualenv:

```
You are using pip version 6.0.7, however version 6.0.8 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

I've made sure my system `pip` and `virtualenv` are all up to date, but that didn't help.

`pip==6.0.8` was added to `virtualenv` a while back in pypa/virtualenv@dccc040b, and is present in the latest tag (12.0.7) but still installs 6.0.7.

This will just force pip to upgrade every time.
