### PR TITLE
Explicity use travis container based system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
 - 2.7

--- a/{{cookiecutter.project_name}}/.travis.yml
+++ b/{{cookiecutter.project_name}}/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
 - 2.7


### PR DESCRIPTION
As shown [here](http://docs.travis-ci.com/user/workers/container-based-infrastructure/), the new docker container build architecture has several advantages, and is [used by fewer projects](https://twitter.com/spacemanLubick/status/582919260076412928) (at least for now).

Before (from the build logs):
```
Using worker: worker-linux-c55820f2-1.bb.travis-ci.org:travis-linux-4
```

After (build logs for this branch):
```
Using worker: worker-linux-docker-45cbeb6a.prod.travis-ci.org:travis-linux-5
```