### PR TITLE
Switch to using a .pep8rc

### DIFF
--- a/{{cookiecutter.project_name}}/.pep8rc
+++ b/{{cookiecutter.project_name}}/.pep8rc
@@ -1,0 +1,3 @@
+[pep8]
+ignore = E501
+max-line-length = 80

--- a/{{cookiecutter.project_name}}/.pep8rc
+++ b/{{cookiecutter.project_name}}/.pep8rc
@@ -1,3 +1,2 @@
 [pep8]
 ignore = E501
-max-line-length = 80

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -150,8 +150,7 @@ check: pep8 pep257 pylint
 
 .PHONY: pep8
 pep8: depends-ci
-# E501: line too long (checked by PyLint)
-	$(PEP8) $(PACKAGE) --ignore=E501
+	$(PEP8) $(PACKAGE) --config=.pep8rc
 
 .PHONY: pep257
 pep257: depends-ci

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.sublime-project
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}.sublime-project
@@ -23,16 +23,15 @@
             },
             "pep8": {
                 "@disable": false,
-                "args": [],
+                "args": ["--config=.pep8rc"],
                 "excludes": [],
-                "ignore": "E501",
-                "max-line-length": 80,
+                "ignore": "",
                 "select": ""
             },
             "pylint": {
                 "@disable": false,
                 "args": [],
-                "disable": "I0011",
+                "disable": "",
                 "enable": "",
                 "excludes": [],
                 "rcfile": ".pylintrc"


### PR DESCRIPTION
PEP8 allows the use of a `.pep8rc` file. While this does add another file to the root, it allows PEP8 editor plugins to share the same options.