### PR TITLE
Prevent travis from clearing cached pip downloads between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - 2.7
 - 3.3
 - 3.4
+cache: pip
 env:
   matrix:
   - TEST_RUNNER=nose

--- a/{{cookiecutter.project_name}}/.travis.yml
+++ b/{{cookiecutter.project_name}}/.travis.yml
@@ -4,6 +4,7 @@ python:
 - 2.7
 - 3.3
 - 3.4
+cache: pip
 install:
 - pip install coveralls scrutinizer-ocular
 before_script:


### PR DESCRIPTION
Between this and the new pip 7.0 building and caching wheels, this should speed up build times by a lot.

http://docs.travis-ci.com/user/caching/#pip-cache

see also: https://github.com/nickstenning/travis-pip-cache