### PR TITLE
Don't show the console coverage report on failures

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -105,7 +105,7 @@ depends: depends-ci depends-dev
 depends-ci: env Makefile $(DEPENDS_CI_FLAG)
 $(DEPENDS_CI_FLAG): Makefile
 	$(PIP) install --upgrade pep8 pep257 pylint coverage
-		{%- if cookiecutter.test_runner == "nose" %} nose
+		{%- if cookiecutter.test_runner == "nose" %} nose nose-cov
 		{%- elif cookiecutter.test_runner == "pytest" %} pytest pytest-cov
 		{%- endif %}
 	@ touch $(DEPENDS_CI_FLAG)  # flag to indicate dependencies are installed
@@ -186,7 +186,7 @@ fix: depends-dev
 
 # Testing ######################################################################
 {% if cookiecutter.test_runner == "nose" %}
-NOSE_OPTS := --with-doctest --with-coverage --cover-package=$(PACKAGE)
+NOSE_OPTS := --with-doctest --with-cov --cov=$(PACKAGE) --cov-report=html
 
 .PHONY: test-unit
 test-unit: test
@@ -194,14 +194,14 @@ test-unit: test
 test: depends-ci .clean-test
 	$(NOSE) $(PACKAGE) $(NOSE_OPTS)
 ifndef TRAVIS
-	$(COVERAGE) html --directory htmlcov --fail-under=$(UNIT_TEST_COVERAGE)
+	$(COVERAGE) report --show-missing --fail-under=$(UNIT_TEST_COVERAGE)
 endif
 
 .PHONY: test-int
 test-int: depends-ci .clean-test
 	$(NOSE) tests $(NOSE_OPTS)
 ifndef TRAVIS
-	$(COVERAGE) html --directory htmlcov --fail-under=$(INTEGRATION_TEST_COVERAGE)
+	$(COVERAGE) report --show-missing --fail-under=$(INTEGRATION_TEST_COVERAGE)
 endif
 
 .PHONY: test-all
@@ -210,29 +210,35 @@ test-all: tests
 tests: depends-ci .clean-test
 	$(NOSE) $(PACKAGE) tests $(NOSE_OPTS) -xv
 ifndef TRAVIS
-	$(COVERAGE) html --directory htmlcov --fail-under=$(COMBINED_TEST_COVERAGE)
+	$(COVERAGE) report --show-missing --fail-under=$(COMBINED_TEST_COVERAGE)
 endif
 {% elif cookiecutter.test_runner == "pytest" %}
-PYTEST_OPTS := --doctest-modules --cov=$(PACKAGE) --cov-report=term-missing --cov-report=html
+PYTEST_OPTS := --doctest-modules --cov=$(PACKAGE) --cov-report=term-missing --no-cov-on-fail
 
 .PHONY: test-unit
 test-unit: test
 .PHONY: test
 test: depends-ci .clean-test
 	$(PYTEST) $(PYTEST_OPTS) $(PACKAGE)
-	$(COVERAGE) report --fail-under=$(UNIT_TEST_COVERAGE) > /dev/null
+ifndef TRAVIS
+	$(COVERAGE) html --directory htmlcov --fail-under=$(UNIT_TEST_COVERAGE)
+endif
 
 .PHONY: test-int
 test-int: depends-ci .clean-test
 	$(PYTEST) $(PYTEST_OPTS) tests
-	$(COVERAGE) report --fail-under=$(INTEGRATION_TEST_COVERAGE) > /dev/null
+ifndef TRAVIS
+	$(COVERAGE) html --directory htmlcov --fail-under=$(INTEGRATION_TEST_COVERAGE)
+endif
 
 .PHONY: test-all
 test-all: tests
 .PHONY: tests
 tests: depends-ci .clean-test
 	$(PYTEST) $(PYTEST_OPTS) $(PACKAGE) tests
-	$(COVERAGE) report --fail-under=$(COMBINED_TEST_COVERAGE) > /dev/null
+ifndef TRAVIS
+	$(COVERAGE) html --directory htmlcov --fail-under=$(COMBINED_TEST_COVERAGE)
+endif
 {% endif %}
 .PHONY: read-coverage
 read-coverage:


### PR DESCRIPTION
Fixes #86

This prevents unnecessary scrolling to debug failures.