### PR TITLE
Show verbose diffs, but quiet test status

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -171,8 +171,9 @@ pep8: depends-ci
 .PHONY: pep257
 pep257: depends-ci
 # D102: docstring missing (checked by PyLint)
-# D202: No blank lines allowed *after* function docstring
-	$(PEP257) $(PACKAGE) --ignore=D102,D202
+# D202: No blank lines allowed *after* function docstring (personal preference)
+# D203: 1 blank line required before class (deprecated warning)
+	$(PEP257) $(PACKAGE) --ignore=D102,D202,D203
 
 .PHONY: pylint
 pylint: depends-ci
@@ -213,7 +214,7 @@ ifndef TRAVIS
 	$(COVERAGE) report --show-missing --fail-under=$(COMBINED_TEST_COVERAGE)
 endif
 {% elif cookiecutter.test_runner == "pytest" %}
-PYTEST_CORE_OPTS := --doctest-modules --quiet -r X --maxfail=3
+PYTEST_CORE_OPTS := --doctest-modules --verbose -r X --maxfail=3
 PYTEST_COV_OPTS := --cov=$(PACKAGE) --cov-report=term-missing --no-cov-on-fail
 PYTEST_RANDOM_OPTS := --random --random-seed=$(TIMESTAMP)
 

--- a/{{cookiecutter.project_name}}/tests/conftest.py
+++ b/{{cookiecutter.project_name}}/tests/conftest.py
@@ -1,0 +1,3 @@
+"""Integration test configuration file."""
+
+from {{cookiecutter.package_name}}.test.conftest import pytest_configure

--- a/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/test/conftest.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.package_name}}/test/conftest.py
@@ -1,0 +1,22 @@
+"""Unit test configuration file."""
+
+
+def pytest_configure(config):
+    """Disable verbose output when running tests."""
+    terminal = config.pluginmanager.getplugin('terminal')
+    base = terminal.TerminalReporter
+
+    class QuietReporter(base):
+        """A py.test reporting that only shows dots when running tests."""
+
+        def __init__(self, *args, **kwargs):
+            # Python 2/3 compatible super class __init__, pylint: disable=E1002
+            if issubclass(base, object):
+                super(base, self).__init__(*args, **kwargs)
+            else:
+                base.__init__(self, *args, **kwargs)
+            self.verbosity = 0
+            self.showlongtestinfo = False
+            self.showfspath = False
+
+    terminal.TerminalReporter = QuietReporter


### PR DESCRIPTION
Based on this hack:
http://stackoverflow.com/questions/30938780/how-can-i-show-verbose-py-test-diffs-without-verbose-test-progress
