### PR TITLE
Python 3.6 is out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ branches:
 language: python
 python:
   - 2.7
-  - 3.3
-  - 3.4
+  - 3.6
   - 3.5
+  - 3.4
+  - 3.3
 
 cache: pip
 


### PR DESCRIPTION
Also change order so most recent 3.x releases tested first.