### PR TITLE
Specify python version when creating virtual environment

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -100,6 +100,7 @@ $(METADATA): $(PYTHON) setup.py
 	@ touch $@
 
 $(PYTHON) $(PIP):
+	pipenv --python=$(SYS_PYTHON)
 	pipenv run pip --version
 
 # CHECKS #######################################################################

--- a/{{cookiecutter.project_name}}/Pipfile
+++ b/{{cookiecutter.project_name}}/Pipfile
@@ -2,9 +2,6 @@
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 
-[requires]
-python_version = "{{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}"
-
 [packages]
 testpackage = "*"
 

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -9,13 +9,13 @@ import setuptools
 
 
 PACKAGE_NAME = '{{cookiecutter.package_name}}'
-MINIMUM_PYTHON_VERSION = {{cookiecutter.python_major_version}}, {{cookiecutter.python_minor_version}}
+MINIMUM_PYTHON_VERSION = '{{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}'
 
 
 def check_python_version():
     """Exit when the Python version is too low."""
-    if sys.version_info < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}.{1}+ is required.".format(*MINIMUM_PYTHON_VERSION))
+    if sys.version < MINIMUM_PYTHON_VERSION:
+        sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
 
 
 def read_package_variable(key, filename='__init__.py'):


### PR DESCRIPTION
It appears that pipenv doesn’t yet do anything with
`requires.python_version`.