### PR TITLE
Fix template error during cookiecutting

### DIFF
--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: {{cookiecutter.project_short_description}}
 site_author: {{cookiecutter.full_name}}
 
 repo_url: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.github_repo}}
-edit_uri: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.github_repo}}/edit/{{{cookiecutter.default_branch}}/docs
+edit_uri: https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.github_repo}}/edit/{{cookiecutter.default_branch}}/docs
 
 theme: readthedocs
 


### PR DESCRIPTION
An extra `{` was introduced in the last master commit. Makes it unable to generate a new project.