### PR TITLE
Look up virtualenv path from poetry

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -9,7 +9,7 @@ CONFIG := $(wildcard *.py)
 MODULES := $(wildcard $(PACKAGE)/*.py)
 
 # Virtual environment paths
-VIRTUAL_ENV ?= .venv
+VIRTUAL_ENV ?= $(shell poetry env info -p || echo .venv)
 
 # MAIN TASKS ##################################################################
 


### PR DESCRIPTION
On my system, the virtualenv path created by poetry is `/Users/brendan/Library/Caches/pypoetry/virtualenvs/hwplatform-47fboew9-py3.8`. When the install step tried to touch a file in `.venv/` it failed, since the directory didn't exist.

I'm not sure why this is the case. When I tried again with another project, it used `.venv/` in the project folder. In any case, to work around this issue, I've modified the Makefile to pull the current virtualenv path from peotry. This should ensure that the file generated during install always uses the correct virtualenv path.