### PR TITLE
Use string python version for github actions

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [{{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}]
+        python-version: ['{{cookiecutter.python_major_version}}.{{cookiecutter.python_minor_version}}']
 
 {%- raw %}
 


### PR DESCRIPTION
By using a string we ensure that yaml does not interpret it as number and removes trailing zeros (e.g. version 3.10 previously became version 3.1)