### PR TITLE
Convert the root .travis.yml file into a GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,63 @@
+name: main
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: Gr1N/setup-poetry@v8
+
+    - name: Check dependencies
+      run: make doctor
+
+    - uses: actions/cache@v4
+      with:
+        path: .venv
+        key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Check everything
+      run: make all
+
+    - name: Checkout demo repo
+      if: github.ref_name == 'main' && github.event_name != 'pull_request'
+      uses: actions/checkout@v4
+      with:
+        repository: jacebrowning/template-python-demo
+        path: temp
+
+    - name: Test template in demo repo
+      if: github.ref_name == 'main' && github.event_name != 'pull_request'
+      run: |
+        # Configure Git with GHA information, for more info see:
+        # https://github.com/actions/checkout?tab=readme-ov-file#push-a-commit-using-the-built-in-token
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        # Delete the current repository
+        rm -rf .git
+
+        # Setup the destination repository
+        mv temp/.git TemplateDemo/.git
+        rm -rf temp
+
+        # Rebuild the repository from the generated files and push to GitHub
+        cd TemplateDemo
+        git add --all
+        git commit -m "Deploy GHA build ${{ github.run_id }} to GitHub"
+        git push


### PR DESCRIPTION
Implements #214.

Hopefully this is in line with what you were looking for @jacebrowning?

* It should be roughly the same as the Travis script except for the second clone operation which I moved out into a dedicated `step` of its own using a native GHA action instead of a raw `git clone`.
* I've also deferred the deletion of the old `.travis.yml` file to leave an overlap period where you can verify the new workflow is working as expected before disabling Travis.
* I'm not sure if I can effectively test the demo repo integration from my fork, so it might be best to try the workflow from the original repo as well, hoping the default built-in tokens have the right scopes and permissions etc.

Let me know if there's anything I've missed :)
